### PR TITLE
Fixed failing "make test"

### DIFF
--- a/test/enetconf_ssh_tests.erl
+++ b/test/enetconf_ssh_tests.erl
@@ -142,6 +142,8 @@ setup() ->
     application:set_env(enetconf, sshd_port, ?PORT),
     application:set_env(enetconf, sshd_shell, {undefined, undefined, []}),
     application:set_env(enetconf, sshd_user_passwords, [{"test", "test"}]),
+    application:start(crypto),
+    application:start(public_key),
     application:start(ssh),
     application:start(xmerl),
     application:start(enetconf).


### PR DESCRIPTION
Fixed enet_ssh_tests.erl to reflect ssh startup changes in R16
Same changes that were made to enetconf_client.erl
