### PR TITLE
Use type tuple() instead of record()

### DIFF
--- a/include/enetconf.hrl
+++ b/include/enetconf.hrl
@@ -30,7 +30,7 @@
                      | candidate %% :candidate capability
                      | running.
 
--type xml() :: {config, record()}.
+-type xml() :: {config, tuple()}.
 
 -type url() :: {url, string()}. %% :url capability
 
@@ -44,7 +44,7 @@
 -type get_config_source() :: config_name()
                            | url().    %% :url capability
 
--type filter() :: {subtree, record()}
+-type filter() :: {subtree, tuple()}
                 | {xpath, string()} %% :xpath capability
                 | undefined.
 

--- a/src/enetconf_ssh.erl
+++ b/src/enetconf_ssh.erl
@@ -39,7 +39,7 @@
           channel_id :: ssh_channel:channel_id(),
           session_id :: integer(),
           parsing_module :: enetconf_frame_end | enetconf_frame_chunk,
-          parser :: record(),
+          parser :: tuple(),
           callback_module :: atom()
          }).
 


### PR DESCRIPTION
Dialyzer doesn't recognize the type `record()`, and gives this error message:

```
dialyzer: Analysis failed with error:
Could not scan the following file(s): [{"/home/magnus/src/LINC-Switch/deps/enetconf/src/gen_netconf.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"},
                                       {"/home/magnus/src/LINC-Switch/deps/enetconf/src/enetconf_xml.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"},
                                       {"/home/magnus/src/LINC-Switch/deps/enetconf/src/enetconf_ssh.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"},
                                       {"/home/magnus/src/LINC-Switch/deps/enetconf/src/enetconf_parser.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"},
                                       {"/home/magnus/src/LINC-Switch/deps/enetconf/src/enetconf_client.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"},
                                       {"/home/magnus/src/LINC-Switch/deps/enetconf/src/enetconf_capabilities.erl",
                                        "  Error while parsing #edit_config{}: Unable to find type record\n\n"}]
```

With `tuple()`, Dialyzer is able to analyse the code.
