### PR TITLE
Don't define integer_to_binary/1 and binary_to_integer/1 in R16B and later

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,8 @@
 {require_otp_vsn, "R1[56]B"}.
 
 {eunit_opts, [verbose]}.
+
+%% If we're using R16B or later, define 'binary_integer_bifs', which
+%% is used in enetconf_fm_chunked.erl to provide compatibility
+%% functions for earlier releases.
+{erl_opts, [{platform_define, "R1[6-9]B", 'binary_integer_bifs'}]}.

--- a/src/enetconf_fm_chunked.erl
+++ b/src/enetconf_fm_chunked.erl
@@ -130,12 +130,17 @@ do_parse(Binary, #chunk_parser{stack = Stack} = Parser, Chunks) ->
 %% Helper functions
 %%------------------------------------------------------------------------------
 
+%% binary_to_integer/1 and integer_to_binary/1 were added as BIFs in
+%% R16B.  Let's compile them conditionally, if we're using an earlier
+%% release.
+-ifndef(binary_integer_bifs).
 %% @private
 integer_to_binary(N) ->
     list_to_binary(integer_to_list(N)).
 
 binary_to_integer(Bin) ->
     list_to_integer(binary_to_list(Bin)).
+-endif.
 
 %% @private
 get_chunk_size(Binary) ->


### PR DESCRIPTION
These functions were finally added as BIFs in R16B. Let's compile them conditionally.

This also gets rid of some compiler warnings.
