### PR TITLE
Introduce separate makefile targets run_client and run_server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,13 @@ clean: rebar
 	@./rebar clean
 	@rm -f .eunit/enetconf
 
-run: compile
+run_server: compile
 	@erl -pa ../$(APP)/ebin -eval \
 	 "[ok = application:start(A) || A <- [crypto, asn1, public_key, ssh, xmerl, enetconf]]"
+
+run_client: compile
+	@erl -pa ../$(APP)/ebin -eval \
+	 "[ok = application:start(A) || A <- [crypto, asn1, public_key, ssh, xmerl]]"
 
 rebar:
 	@wget -q http://cloud.github.com/downloads/basho/rebar/rebar


### PR DESCRIPTION
The previous "run" target corresponds to the new "run_server".  It
listens for connections on port 1830, so it cannot be run at the same
time as the LINC switch in its default configuration.

The wiki page currently suggests "erl -pa ebin" to start an Erlang shell
to be used as a client.  This is inconvenient, since the ssh
application (and its dependencies) need to be started in order to
connect to a server.
