### PR TITLE
Fix case_clause in enetconf_ssh; pass message id on parse error

### DIFF
--- a/src/enetconf_ssh.erl
+++ b/src/enetconf_ssh.erl
@@ -91,7 +91,7 @@ handle_ssh_msg({ssh_cm, ConnRef, {data, ChannelId, ?DATA_TYPE_CODE, Data}},
                             NewState = handle_messages(Rest, TempState),
                             {ok, NewState}
                     end;
-                {error, _} ->
+                {error, _, _} ->
                     %% TODO: Send an error
                     ?WARNING("Invalid hello: ~p~n", [FirstMessage]),
                     {stop, ChannelId, State}


### PR DESCRIPTION
enetconf_ssh:parse_xml expects to get a tuple with three arguments, one
being the message id.  Let's make sure it gets that, instead of causing
a case_clause error.

With this change, we can send error replies for incorrect requests
instead of just dropping the connection.
